### PR TITLE
Avoid logging errors by mocking global flags

### DIFF
--- a/differ.py
+++ b/differ.py
@@ -10,6 +10,14 @@ from functions import tidy
 from dbt.contracts.graph.manifest import WritableManifest
 from dbt.graph.selector_methods import StateSelectorMethod
 
+# To support logging events, mock the 'list' command with default CLI options
+from dbt.cli.flags import Flags
+from dbt.flags import set_flags
+from dbt.cli.types import Command as CliCommand
+
+flags = Flags.from_dict(CliCommand.LIST, {})
+set_flags(flags)
+
 class MockPreviousState:
     def __init__(self, manifest: WritableManifest) -> None:
         self.manifest: Manifest = manifest
@@ -77,7 +85,7 @@ if left_file and right_file:
         st.write(state_comparator.modified_macros)
     
     if len(selected_nodes) == 0:
-        st.write("No diffs!")
+        st.write("No nodes selected!")
     
     st.header(f"{len(selected_nodes)} Selected node{'s' if len(selected_nodes) != 1 else ''}")
     for unique_id in selected_nodes:

--- a/functions/flatten.py
+++ b/functions/flatten.py
@@ -6,7 +6,7 @@ def flatten_keys(dictionary, separator="."):
     for key, value in dictionary.items():
         if isinstance(value, Mapping):
             result.update(
-                (key + separator + k, v if v is not None else ['N/A'])
+                (str(key) + str(separator) + str(k), v if v is not None else ['N/A'])
                 for k, v in flatten_keys(value, separator).items()
             )
         else:


### PR DESCRIPTION
In cases where dbt encounters a seed that is >1 MB in size, it will fire an event that is either `warn_or_error`, depending on the value of the global `WARN_ERROR` flag.

Mock the global `Flags` by pretending that this is the `list` command with default CLI options.

dbt-core will still write its logging events to stdout (the terminal running `streamlit`). A future enhancement could try playing with [`contextlib.redirect_stdout`](https://docs.python.org/3/library/contextlib.html#contextlib.redirect_stdout) to show these log messages in the streamlit app UI instead.